### PR TITLE
Support external URLs

### DIFF
--- a/Model/MenuLinkManagement.php
+++ b/Model/MenuLinkManagement.php
@@ -236,6 +236,8 @@ class MenuLinkManagement implements MenuLinkManagementInterface
 
     private function getLinkUrl($data)
     {
+        if (preg_match('/^(tel|ftps?|https?|mailto):\/\//i', $data['link_url']))
+             return $data['link_url'];
         return $this->urlBuilder->getUrl(null, ['_direct' => $data['link_url']]);
     }
     /**


### PR DESCRIPTION
This PR adds support for URLs outside your Magento2 instance.

If custom/static link contains http(s), ftp(s), mailto or tel, a link is considered external and your Magento2 store URL will not be prefixed in the link URL.

Sponsored-by: Hypernova Oy
https://www.hypernova.fi